### PR TITLE
Remove support for newick and gff files until we are sure they work.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,16 +28,6 @@ const TYPES: {[key: string]: {name: string, extensions: string[], reader: any}} 
     extensions: ['.clustal', '.aln'],
     reader: msa.io.clustal
   },
-  'application/vnd.newick.newick': {
-    name: 'Newick',
-    extensions: ['.nwk'],
-    reader: msa.io.newick
-  },
-  'application/vnd.gff.gff': {
-    name: 'GFF',
-    extensions: ['.gff'],
-    reader: msa.io.gff
-  }
 };
 
 /**


### PR DESCRIPTION
If someone can supply a sample newick or gff file, and we can verify it works, we can enable this again.

We should probably also commit a sample clustal file so we can verify it works.

Fixes #8